### PR TITLE
switch meriam to merriam everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Some configuration values can also be specified via environment variables. This 
 
 The following environment variables are read by **define**'s sources:
 
-- `MERIAM_WEBSTER_DICTIONARY_APP_KEY`
+- `MERRIAM_WEBSTER_DICTIONARY_APP_KEY`
 - `OXFORD_DICTIONARY_APP_ID`
 - `OXFORD_DICTIONARY_APP_KEY`
 

--- a/source/webster/provider.go
+++ b/source/webster/provider.go
@@ -41,7 +41,7 @@ func initConfig(flags *flag.FlagSet) *config {
 	conf := &config{}
 
 	// Define our flags
-	flags.StringVar(&conf.AppKey, "meriam-webster-dictionary-app-key", "", fmt.Sprintf("The app key for the %s", Name))
+	flags.StringVar(&conf.AppKey, "merriam-webster-dictionary-app-key", "", fmt.Sprintf("The app key for the %s", Name))
 
 	return conf
 }
@@ -76,7 +76,7 @@ func (c *config) UnmarshalJSON(data []byte) error {
 
 func (c *config) Finalize() {
 	if "" == c.AppKey {
-		c.AppKey = os.Getenv("MERIAM_WEBSTER_DICTIONARY_APP_KEY")
+		c.AppKey = os.Getenv("MERRIAM_WEBSTER_DICTIONARY_APP_KEY")
 	}
 }
 


### PR DESCRIPTION
`merriam` was misspelled in a few places