### PR TITLE
Feature - Free Dictionary API Source

### DIFF
--- a/define.go
+++ b/define.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Rican7/define/source"
 	flag "github.com/ogier/pflag"
 
+	_ "github.com/Rican7/define/source/freedictionaryapi"
 	_ "github.com/Rican7/define/source/glosbe"
 	"github.com/Rican7/define/source/oxford"
 	_ "github.com/Rican7/define/source/webster"

--- a/source/freedictionaryapi/apidata.go
+++ b/source/freedictionaryapi/apidata.go
@@ -1,0 +1,163 @@
+// Copyright © 2023 Trevor N. Suarez (Rican7)
+
+package freedictionaryapi
+
+import (
+	"strings"
+
+	"github.com/Rican7/define/source"
+)
+
+const (
+	// apiPhoneticsWrapper defines the character used to wrap phonetics strings
+	// in the Free Dictionary API
+	apiPhoneticsWrapper = '/'
+)
+
+// apiResponse defines the data structure for a Free Dictionary API response
+type apiResponse []apiResult
+
+// apiResult defines the data structure for a Free Dictionary API result
+type apiResult struct {
+	Word       string         `json:"word"`
+	Phonetic   string         `json:"phonetic"`
+	Phonetics  []apiPhonetics `json:"phonetics"`
+	Meanings   []apiMeaning   `json:"meanings"`
+	License    apiLicense     `json:"license"`
+	SourceUrls []string       `json:"sourceUrls"`
+}
+
+// apiPhonetics defines the data structure for Free Dictionary API phonetics
+type apiPhonetics struct {
+	Text      string     `json:"text"`
+	Audio     string     `json:"audio"`
+	SourceURL string     `json:"sourceUrl"`
+	License   apiLicense `json:"license"`
+}
+
+// apiPhonetics defines the data structure for Free Dictionary API phonetics
+type apiMeaning struct {
+	PartOfSpeech string          `json:"partOfSpeech"`
+	Definitions  []apiDefinition `json:"definitions"`
+
+	apiThesaurusValues
+}
+
+// apiDefinition defines the data structure for a Free Dictionary API definition
+type apiDefinition struct {
+	Definition string `json:"definition"`
+	Example    string `json:"example"`
+
+	apiThesaurusValues
+}
+
+// apiThesaurusValues defines the data structure for Free Dictionary API
+// thesaurus values
+type apiThesaurusValues struct {
+	Synonyms []string `json:"synonyms"`
+	Antonyms []string `json:"antonyms"`
+}
+
+// apiLicense defines the data structure for a Free Dictionary API license
+type apiLicense struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+// toResult converts the API response to the results that a source expects to
+// return.
+func (r apiResponse) toResults() []source.DictionaryResult {
+	sourceResults := make([]source.DictionaryResult, 0, len(r))
+
+	for _, result := range r {
+		sourceEntries := make([]source.DictionaryEntry, 0, len(result.Meanings))
+
+		var pronunciations []string
+		if result.Phonetic != "" {
+			pronunciation := cleanPhoneticText(result.Phonetic)
+
+			pronunciations = append(pronunciations, pronunciation)
+		}
+
+		for _, phonetic := range result.Phonetics {
+			if phonetic.Text == "" {
+				continue
+			}
+
+			pronunciation := cleanPhoneticText(phonetic.Text)
+
+			if len(pronunciations) < 1 || pronunciations[0] != pronunciation {
+				pronunciations = append(pronunciations, pronunciation)
+			}
+		}
+
+		for _, apiMeaning := range result.Meanings {
+			sourceEntry := apiMeaning.toEntry()
+
+			sourceEntry.Word = result.Word
+			sourceEntry.Pronunciations = pronunciations
+
+			sourceEntries = append(sourceEntries, sourceEntry)
+		}
+
+		sourceResults = append(
+			sourceResults,
+			source.DictionaryResult{
+				Language: "en", // TODO
+				Entries:  sourceEntries,
+			},
+		)
+	}
+
+	return sourceResults
+}
+
+// toEntry converts the API meaning to a source.DictionaryEntry
+func (m *apiMeaning) toEntry() source.DictionaryEntry {
+	sourceEntry := source.DictionaryEntry{}
+
+	sourceEntry.LexicalCategory = m.PartOfSpeech
+
+	for _, apiDefinition := range m.Definitions {
+		sourceSense := apiDefinition.toSense()
+
+		sourceEntry.Senses = append(sourceEntry.Senses, sourceSense)
+	}
+
+	sourceEntry.ThesaurusValues = m.apiThesaurusValues.toThesaurusValues()
+
+	return sourceEntry
+}
+
+// toThesaurusValues converts API thesaurus values to a source.ThesaurusValues
+func (v *apiThesaurusValues) toThesaurusValues() source.ThesaurusValues {
+	return source.ThesaurusValues{
+		Synonyms: v.Synonyms,
+		Antonyms: v.Antonyms,
+	}
+}
+
+// toSense converts the API definition to a source.Sense
+func (d *apiDefinition) toSense() source.Sense {
+	var definitions []string
+	var examples []string
+
+	if d.Definition != "" {
+		definitions = []string{d.Definition}
+	}
+
+	if d.Example != "" {
+		examples = []string{d.Example}
+	}
+
+	return source.Sense{
+		Definitions: definitions,
+		Examples:    examples,
+
+		ThesaurusValues: d.apiThesaurusValues.toThesaurusValues(),
+	}
+}
+
+func cleanPhoneticText(text string) string {
+	return strings.Trim(text, string(apiPhoneticsWrapper))
+}

--- a/source/freedictionaryapi/freedictionaryapi.go
+++ b/source/freedictionaryapi/freedictionaryapi.go
@@ -1,0 +1,117 @@
+// Copyright © 2023 Trevor N. Suarez (Rican7)
+
+// Package freedictionaryapi provides a dictionary source via the "Free
+// Dictionary API"
+package freedictionaryapi
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/Rican7/define/source"
+)
+
+// Name defines the name of the source
+const Name = "Free Dictionary API"
+
+const (
+	// baseURLString is the base URL for all Free Dictionary API interactions
+	baseURLString = "https://api.dictionaryapi.dev/api/v2/"
+
+	entriesURLString = baseURLString + "entries/"
+
+	httpRequestAcceptHeaderName = "Accept"
+
+	jsonMIMEType = "application/json"
+)
+
+// apiURL is the URL instance used for Free Dictionary API calls
+var apiURL *url.URL
+
+// validMIMETypes is the list of valid response MIME types
+var validMIMETypes = []string{jsonMIMEType}
+
+// api is a struct containing a configured HTTP client for Free Dictionary API operations
+type api struct {
+	httpClient *http.Client
+}
+
+// Initialize the package
+func init() {
+	var err error
+
+	apiURL, err = url.Parse(baseURLString)
+
+	if err != nil {
+		panic(err)
+	}
+}
+
+// New returns a new Free Dictionary API dictionary source
+func New(httpClient http.Client) source.Source {
+	return &api{&httpClient}
+}
+
+// Name returns the printable, human-readable name of the source.
+func (g *api) Name() string {
+	return Name
+}
+
+// Define takes a word string and returns a list of dictionary results, and
+// an error if any occurred.
+func (g *api) Define(word string) ([]source.DictionaryResult, error) {
+	// Prepare our URL
+	requestURL, err := url.Parse(entriesURLString + "en/" + word)
+
+	if err != nil {
+		return nil, err
+	}
+
+	httpRequest, err := http.NewRequest(http.MethodGet, apiURL.ResolveReference(requestURL).String(), nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	httpRequest.Header.Set(httpRequestAcceptHeaderName, jsonMIMEType)
+
+	httpResponse, err := g.httpClient.Do(httpRequest)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer httpResponse.Body.Close()
+
+	if http.StatusNotFound == httpResponse.StatusCode {
+		return nil, &source.EmptyResultError{Word: word}
+	}
+
+	if http.StatusForbidden == httpResponse.StatusCode {
+		return nil, &source.AuthenticationError{}
+	}
+
+	if err = source.ValidateHTTPResponse(httpResponse, validMIMETypes, nil); err != nil {
+		return nil, err
+	}
+
+	body, err := io.ReadAll(httpResponse.Body)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var response apiResponse
+
+	if err = json.Unmarshal(body, &response); err != nil {
+		return nil, err
+	}
+
+	if len(response) < 1 {
+		return nil, &source.EmptyResultError{Word: word}
+	}
+
+	return source.ValidateAndReturnDictionaryResults(word, response.toResults())
+}

--- a/source/freedictionaryapi/provider.go
+++ b/source/freedictionaryapi/provider.go
@@ -1,0 +1,45 @@
+// Copyright © 2023 Trevor N. Suarez (Rican7)
+
+package freedictionaryapi
+
+import (
+	"net/http"
+
+	flag "github.com/ogier/pflag"
+
+	"github.com/Rican7/define/registry"
+	"github.com/Rican7/define/source"
+)
+
+// RequiredConfigError represents an error when a required configuration key is
+// missing or invalid.
+type RequiredConfigError struct {
+	Key string
+}
+
+type config struct{}
+
+type provider struct{}
+
+// JSONKey defines the JSON key used for the provider
+const JSONKey = "FreeDictionaryAPI"
+
+func init() {
+	registry.Register(registry.RegisterFunc(register))
+}
+
+func register(*flag.FlagSet) (registry.SourceProvider, registry.Configuration) {
+	return &provider{}, &config{}
+}
+
+func (c *config) JSONKey() string {
+	return JSONKey
+}
+
+func (p *provider) Name() string {
+	return Name
+}
+
+func (p *provider) Provide(conf registry.Configuration) (source.Source, error) {
+	return New(http.Client{}), nil
+}


### PR DESCRIPTION
This PR adds a new source to the app, the ["Free Dictionary API"](https://dictionaryapi.dev/).

The "Glosbe" source doesn't seem to be working anymore, and it was the only source that didn't require an API key... so I went looking for a replacement and stumbled upon the "Free Dictionary API". Thanks to @meetDeveloper for creating this **and** making it [open-source](https://github.com/meetDeveloper/freeDictionaryAPI)!

The structure is also pretty easy to work with! So this was only a couple of hours of work to implement and test! 😃