### PR TITLE
Feature - Dictionary Word Search and Empty Define Result Fallback

### DIFF
--- a/internal/io/printer/printer.go
+++ b/internal/io/printer/printer.go
@@ -73,6 +73,15 @@ func (p *ResultPrinter) PrintDictionaryResults(results []source.DictionaryResult
 	})
 }
 
+// PrintSearchResults prints a list of search results
+func (p *ResultPrinter) PrintSearchResults(results []string) {
+	p.out.IndentWrites(func(writer *defineio.PanicWriter) {
+		for index, result := range results {
+			writer.WriteStringLine(fmt.Sprintf("%d. %s", index+1, result))
+		}
+	})
+}
+
 func printDictionaryEntry(writer *defineio.PanicWriter, entry source.DictionaryEntry) {
 	if entry.LexicalCategory != "" {
 		writer.WritePaddedStringLine(fmt.Sprintf("(%s)", entry.LexicalCategory), 1)

--- a/source/error.go
+++ b/source/error.go
@@ -54,6 +54,27 @@ func ValidateAndReturnDictionaryResults(word string, results []DictionaryResult)
 	return results, nil
 }
 
+// ValidateSearchResults validates the results of a search operation and returns
+// an error if they're invalid
+func ValidateSearchResults(word string, results []string) error {
+	if len(results) < 1 {
+		return &EmptyResultError{word}
+	}
+
+	return nil
+}
+
+// ValidateAndReturnSearchResults validates the results of a search operation
+// and returns the results and a nil error if valid. If invalid, it'll return
+// nil results and an error.
+func ValidateAndReturnSearchResults(word string, results []string) ([]string, error) {
+	if err := ValidateSearchResults(word, results); err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
 // ValidateHTTPResponse validates an HTTP response and returns an error if the
 // response is invalid
 func ValidateHTTPResponse(httpResponse *http.Response, validContentTypes []string, validStatusCodes []int) error {

--- a/source/error_test.go
+++ b/source/error_test.go
@@ -15,7 +15,7 @@ var (
 	_ error = (*InvalidResponseError)(nil)
 )
 
-func TestValidateResult(t *testing.T) {
+func TestValidateDictionaryResults(t *testing.T) {
 	testData := []struct {
 		word   string
 		result []DictionaryResult
@@ -34,7 +34,7 @@ func TestValidateResult(t *testing.T) {
 	}
 }
 
-func TestValidateAndReturnResult(t *testing.T) {
+func TestValidateAndReturnDictionaryResults(t *testing.T) {
 	testData := []struct {
 		word    string
 		result  []DictionaryResult
@@ -55,6 +55,50 @@ func TestValidateAndReturnResult(t *testing.T) {
 
 		if !tt.wantErr && !reflect.DeepEqual(got, tt.result) {
 			t.Errorf("ValidateAndReturnDictionaryResults returned wrong value. Got %#v. Want %#v.", got, tt.result)
+		}
+	}
+}
+
+func TestValidateSearchResults(t *testing.T) {
+	testData := []struct {
+		word   string
+		result []string
+		want   error
+	}{
+		{word: "", result: nil, want: &EmptyResultError{}},
+		{word: "", result: []string{}, want: &EmptyResultError{}},
+		{word: "test", result: []string{}, want: &EmptyResultError{Word: "test"}},
+		{word: "test", result: []string{"test"}, want: nil},
+	}
+
+	for _, tt := range testData {
+		if got := ValidateSearchResults(tt.word, tt.result); !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("ValidateSearchResults returned wrong value. Got %#v. Want %#v.", got, tt.want)
+		}
+	}
+}
+
+func TestValidateAndReturnSearchResults(t *testing.T) {
+	testData := []struct {
+		word    string
+		result  []string
+		wantErr bool
+	}{
+		{word: "", result: nil, wantErr: true},
+		{word: "", result: []string{}, wantErr: true},
+		{word: "test", result: []string{}, wantErr: true},
+		{word: "test", result: []string{"test"}, wantErr: false},
+	}
+
+	for _, tt := range testData {
+		got, err := ValidateAndReturnSearchResults(tt.word, tt.result)
+
+		if (err != nil) != tt.wantErr {
+			t.Errorf("ValidateAndReturnSearchResults returned an error when not expected. Got %#v.", err)
+		}
+
+		if !tt.wantErr && !reflect.DeepEqual(got, tt.result) {
+			t.Errorf("ValidateAndReturnSearchResults returned wrong value. Got %#v. Want %#v.", got, tt.result)
 		}
 	}
 }

--- a/source/freedictionaryapi/apidata.go
+++ b/source/freedictionaryapi/apidata.go
@@ -14,11 +14,11 @@ const (
 	apiPhoneticsWrapper = '/'
 )
 
-// apiResponse defines the data structure for a Free Dictionary API response
-type apiResponse []apiResult
+// apiResponse defines the structure of a Free Dictionary API response
+type apiResponse []apiDefinitionResult
 
-// apiResult defines the data structure for a Free Dictionary API result
-type apiResult struct {
+// apiDefinitionResult defines the structure of a Free Dictionary API result
+type apiDefinitionResult struct {
 	Word       string         `json:"word"`
 	Phonetic   string         `json:"phonetic"`
 	Phonetics  []apiPhonetics `json:"phonetics"`
@@ -27,7 +27,7 @@ type apiResult struct {
 	SourceUrls []string       `json:"sourceUrls"`
 }
 
-// apiPhonetics defines the data structure for Free Dictionary API phonetics
+// apiPhonetics defines the structure of Free Dictionary API phonetics
 type apiPhonetics struct {
 	Text      string     `json:"text"`
 	Audio     string     `json:"audio"`
@@ -35,7 +35,7 @@ type apiPhonetics struct {
 	License   apiLicense `json:"license"`
 }
 
-// apiPhonetics defines the data structure for Free Dictionary API phonetics
+// apiPhonetics defines the structure of Free Dictionary API phonetics
 type apiMeaning struct {
 	PartOfSpeech string          `json:"partOfSpeech"`
 	Definitions  []apiDefinition `json:"definitions"`
@@ -43,7 +43,7 @@ type apiMeaning struct {
 	apiThesaurusValues
 }
 
-// apiDefinition defines the data structure for a Free Dictionary API definition
+// apiDefinition defines the structure of a Free Dictionary API definition
 type apiDefinition struct {
 	Definition string `json:"definition"`
 	Example    string `json:"example"`
@@ -51,14 +51,14 @@ type apiDefinition struct {
 	apiThesaurusValues
 }
 
-// apiThesaurusValues defines the data structure for Free Dictionary API
-// thesaurus values
+// apiThesaurusValues defines the structure of Free Dictionary API thesaurus
+// values
 type apiThesaurusValues struct {
 	Synonyms []string `json:"synonyms"`
 	Antonyms []string `json:"antonyms"`
 }
 
-// apiLicense defines the data structure for a Free Dictionary API license
+// apiLicense defines the structure of a Free Dictionary API license
 type apiLicense struct {
 	Name string `json:"name"`
 	URL  string `json:"url"`

--- a/source/oxford/apidata.go
+++ b/source/oxford/apidata.go
@@ -6,15 +6,15 @@ import (
 	"github.com/Rican7/define/source"
 )
 
-// apiResponse defines the data structure for an Oxford API response
+// apiResponse defines the structure of an Oxford API response
 type apiResponse struct {
 	Metadata struct {
 	} `json:"metadata"`
-	Results []apiResult `json:"results"`
+	Results []apiDefinitionResult `json:"results"`
 }
 
-// apiResult defines the data structure for an Oxford API result
-type apiResult struct {
+// apiDefinitionResult defines the structure of an Oxford API definition result
+type apiDefinitionResult struct {
 	ID             string             `json:"id"`
 	Language       string             `json:"language"`
 	LexicalEntries []apiLexicalEntry  `json:"lexicalEntries"`
@@ -23,7 +23,7 @@ type apiResult struct {
 	Word           string             `json:"word"`
 }
 
-// apiLexicalEntry defines the data structure for an Oxford API lexical entry
+// apiLexicalEntry defines the structure of an Oxford API lexical entry
 type apiLexicalEntry struct {
 	Compounds    []apiWordReference `json:"compounds"`
 	DerivativeOf []apiWordReference `json:"derivativeOf"`
@@ -52,7 +52,7 @@ type apiLexicalEntry struct {
 	VariantForms        []apiVariantForm   `json:"variantForms"`
 }
 
-// apiWordReference defines the data structure for an Oxford API word reference
+// apiWordReference defines the structure of an Oxford API word reference
 type apiWordReference struct {
 	Domains   []apiIDText `json:"domains"`
 	ID        string      `json:"id"`
@@ -62,20 +62,20 @@ type apiWordReference struct {
 	Text      string      `json:"text"`
 }
 
-// apiIDText defines the data structure for an Oxford API text with ID
+// apiIDText defines the structure of an Oxford API text with ID
 type apiIDText struct {
 	ID   string `json:"id"`
 	Text string `json:"text"`
 }
 
-// apiTypedIDText defines the data structure for an Oxford API typed, ID'd text
+// apiTypedIDText defines the structure of an Oxford API typed, ID'd text
 type apiTypedIDText struct {
 	apiIDText
 
 	Type string `json:"type"`
 }
 
-// apiInflection defines the data structure for an Oxford API inflection
+// apiInflection defines the structure of an Oxford API inflection
 type apiInflection struct {
 	Domains             []apiIDText        `json:"domains"`
 	GrammaticalFeatures []apiTypedIDText   `json:"grammaticalFeatures"`
@@ -86,7 +86,7 @@ type apiInflection struct {
 	Registers           []apiIDText        `json:"registers"`
 }
 
-// apiVariantForm defines the data structure for an Oxford API variant form
+// apiVariantForm defines the structure of an Oxford API variant form
 type apiVariantForm struct {
 	Domains        []apiIDText        `json:"domains"`
 	Notes          []apiTypedIDText   `json:"notes"`
@@ -96,7 +96,7 @@ type apiVariantForm struct {
 	Text           string             `json:"text"`
 }
 
-// apiSense defines the data structure for an Oxford API "sense"
+// apiSense defines the structure of an Oxford API "sense"
 type apiSense struct {
 	Antonyms      []apiWordReference `json:"antonyms"`
 	Constructions []struct {
@@ -131,7 +131,7 @@ type apiSense struct {
 	VariantForms []apiVariantForm `json:"variantForms"`
 }
 
-// apiComplexExample defines the data structure for an Oxford API "example"
+// apiComplexExample defines the structure of an Oxford API "example"
 type apiComplexExample struct {
 	Definitions []string         `json:"definitions"`
 	Domains     []apiIDText      `json:"domains"`
@@ -142,7 +142,7 @@ type apiComplexExample struct {
 	Text        string           `json:"text"`
 }
 
-// apiPronunciation defines the data structure for an Oxford API "pronunciation"
+// apiPronunciation defines the structure of an Oxford API "pronunciation"
 type apiPronunciation struct {
 	AudioFile        string      `json:"audioFile"`
 	Dialects         []string    `json:"dialects"`

--- a/source/source.go
+++ b/source/source.go
@@ -26,13 +26,13 @@ type DictionaryResult struct {
 	Entries  []DictionaryEntry
 }
 
-// Entry defines the structure for an entry of a specific word
+// Entry defines the structure of an entry of a specific word
 type Entry struct {
 	Word            string
 	LexicalCategory string
 }
 
-// DictionaryEntry defines the structure for a dictionary entry of a word
+// DictionaryEntry defines the structure of a dictionary entry of a word
 type DictionaryEntry struct {
 	Entry
 
@@ -73,7 +73,7 @@ type Attribution struct {
 	Source string
 }
 
-// ThesaurusValues defines the structure for the thesaurus values of a word
+// ThesaurusValues defines the structure of the thesaurus values of a word
 type ThesaurusValues struct {
 	Synonyms []string // Words with similar meaning
 	Antonyms []string // Words with the opposite meaning

--- a/source/source.go
+++ b/source/source.go
@@ -19,6 +19,13 @@ type Source interface {
 	Define(word string) ([]DictionaryResult, error)
 }
 
+// Searcher defines an interface for a source that supports search capabilities
+type Searcher interface {
+	// Search takes a word string and returns a list of found words, and an
+	// error if any occurred.
+	Search(word string, limit uint) ([]string, error)
+}
+
 // DictionaryResult defines the structure of a dictionary word result in a
 // specific language
 type DictionaryResult struct {

--- a/source/webster/apidata.go
+++ b/source/webster/apidata.go
@@ -257,6 +257,21 @@ func (r apiDefinitionResults) toResults() []source.DictionaryResult {
 	}
 }
 
+// toResult converts the API response to the results that a source expects to
+// return.
+func (r apiSearchResults) toResults() []string {
+	sourceResults := make([]string, 0, len(r))
+
+	for _, apiResult := range r {
+		sourceResults = append(
+			sourceResults,
+			string(apiResult),
+		)
+	}
+
+	return sourceResults
+}
+
 // toSenses converts the API sense sequence to a list of source.Sense
 func (s apiSenseSequence) toSenses() []source.Sense {
 	senses := make([]source.Sense, 0)

--- a/source/webster/apidata.go
+++ b/source/webster/apidata.go
@@ -45,10 +45,10 @@ var (
 	regexpWebsterSenseNumber = regexp.MustCompile(`(\d+)? ?(\w+)? ?(\(\d+\))?`)
 )
 
-// apiRawResponse defines the data structure for a raw Webster API response
+// apiRawResponse defines the structure of a raw Webster API response
 type apiRawResponse []any
 
-// apiResponse defines the data structure for a Webster API response
+// apiResponse defines the structure of a Webster API response
 type apiResponse[T apiResponseItem] []T
 
 // apiResponseItem defines a type constraint for Webster API response items
@@ -56,17 +56,16 @@ type apiResponseItem interface {
 	apiSearchResult | apiDefinitionResult
 }
 
-// apiSearchResults defines the data for Webster API search results
+// apiSearchResults defines the structure of Webster API search results
 type apiSearchResults []apiSearchResult
 
-// apiDefinitionResults defines the data for Webster API definition results
+// apiDefinitionResults defines the structure of Webster API definition results
 type apiDefinitionResults []apiDefinitionResult
 
-// apiSearchResult defines the data for a Webster API search result
+// apiSearchResult defines the structure of a Webster API search result
 type apiSearchResult string
 
-// apiDefinitionResult defines the data structure for a Webster API definition
-// result
+// apiDefinitionResult defines the structure of a Webster API definition result
 type apiDefinitionResult struct {
 	Meta apiDefinitionMeta         `json:"meta"`
 	Hom  int                       `json:"hom"`
@@ -93,7 +92,7 @@ type apiDefinitionResult struct {
 	Shortdef []string `json:"shortdef"`
 }
 
-// apiDefinitionMeta defines the data structure for Webster API definition meta
+// apiDefinitionMeta defines the structure of Webster API definition meta
 type apiDefinitionMeta struct {
 	ID        string   `json:"id"`
 	UUID      string   `json:"uuid"`
@@ -104,8 +103,8 @@ type apiDefinitionMeta struct {
 	Offensive bool     `json:"offensive"`
 }
 
-// apiDefinitionMeta defines the data structure for Webster API definition
-// headword information
+// apiDefinitionMeta defines the structure of Webster API definition headword
+// information
 type apiDefinitionHeadwordInfo struct {
 	Hw  string `json:"hw"`
 	Prs []struct {
@@ -118,30 +117,30 @@ type apiDefinitionHeadwordInfo struct {
 	} `json:"prs"`
 }
 
-// apiDefinitionSectionEntry defines the data structure for Webster API
-// definition section entries
+// apiDefinitionSectionEntry defines the structure of Webster API definition
+// section entries
 type apiDefinitionSectionEntry struct {
 	Vd   string           `json:"vd"`
 	Sseq apiSenseSequence `json:"sseq"`
 }
 
-// apiSenseSequence defines the data structure for a Webster API sense sequence
+// apiSenseSequence defines the structure of a Webster API sense sequence
 type apiSenseSequence []apiSense
 
-// apiSense defines the data structure for a Webster API sense
+// apiSense defines the structure of a Webster API sense
 type apiSense [][]any
 
-// apiSenseData defines the data structure for a Webster API sense data
+// apiSenseData defines the structure of a Webster API sense data
 type apiSenseData map[string]any
 
-// apiSenseNumber defines the data structure for a Webster API sense number
+// apiSenseNumber defines the structure of a Webster API sense number
 type apiSenseNumber struct {
 	number int
 	letter string
 	sub    string
 }
 
-// apiExample defines the data structure for a Webster API example
+// apiExample defines the structure of a Webster API example
 type apiExample map[string]any
 
 // UnmarshalJSON satisfies the encoding/json.Unmarshaler interface


### PR DESCRIPTION
_Ok, this is a cool one..._

This PR adds a couple of main features: the optional capability for sources to expose a word search, and an automatic fallback to using that word search and displaying those results when an otherwise empty result is returned from a define action.

<details>
<summary>Now, when a word is attempted to be defined, but the source returns an empty result, then a search will be conducted to show suggestions if the source implements an optional interface. Yay!</summary>

<img src="https://user-images.githubusercontent.com/742384/220808799-8c37ce36-abe7-4e20-919c-ab870f963381.png" alt="image" width="604" style="max-width: 100%;">
</details>

