### PR TITLE
Feature - Oxford Source Automatic Inflection Correction

### DIFF
--- a/source/oxford/apidata.go
+++ b/source/oxford/apidata.go
@@ -7,6 +7,10 @@ import (
 	"github.com/Rican7/define/source"
 )
 
+const (
+	apiSearchResultMatchTypeInflection = "inflection"
+)
+
 // apiDefinitionResponse defines the structure of an Oxford API define response
 type apiDefinitionResponse struct {
 	Metadata struct {


### PR DESCRIPTION
This PR adds an automatic inflection correction fallback for the Oxford source.

Previously, if you tried to define a word like `dogs`, `pixels`, or similar, the Oxford source would return an empty result. This PR introduces a fallback mechanism that upon an empty result being returned for a word, will then search the dictionary for a similar word that comes from the inflection, and then show results for that instead.

The other sources (Merriam-Webster and Free Dictionary API) already do this automatically on their server-side, so this change puts the Oxford source closer in-line to their behaviors.